### PR TITLE
Pluralize model to follow Lithium's conventions

### DIFF
--- a/config/bootstrap/connections.php
+++ b/config/bootstrap/connections.php
@@ -17,7 +17,7 @@ Connections::add('default', array(
 Connections::add('test', array(
 	'adapter' => 'MongoDb',
 	'host' => 'localhost',
-	'database' => 'test'
+	'database' => 'lithosphere_test'
 ));
 
 Connections::add('li3_users', array(

--- a/controllers/PostsController.php
+++ b/controllers/PostsController.php
@@ -2,7 +2,7 @@
 
 namespace app\controllers;
 
-use app\models\Post;
+use app\models\Posts;
 use lithium\storage\Session;
 
 class PostsController extends \lithium\action\Controller {
@@ -15,7 +15,7 @@ class PostsController extends \lithium\action\Controller {
 		}
 		$errors = false;
 		if (!empty($this->request->data)) {
-			$post = Post::create($this->request->data);
+			$post = Posts::create($this->request->data);
 			if ($post->save()) {
 				return $this->redirect(array(
 					'controller' => 'posts', 'action' => 'comment',
@@ -26,20 +26,19 @@ class PostsController extends \lithium\action\Controller {
 			}
 		}
 		if (empty($post)) {
-			$post = Post::create();
+			$post = Posts::create();
 		}
-		$tags = Post::$tags;
+		$tags = Posts::$tags;
 		return compact('post','tags','errors');
 	}
 
 	public function comment() {
 		$user = Session::read('user', array('name' => 'li3_user'));
 
-		$post = Post::first($this->request->params['_id']);
+		$post = Posts::first($this->request->params['_id']);
 		if (empty($post)) {
 			return $this->redirect(array('controller' => 'posts', 'action' => 'index'));
 		}
-		//print_r($post->data()); die();
 
 		$endorsed =
 			($user['_id'] == $post->user_id) ||
@@ -72,7 +71,7 @@ class PostsController extends \lithium\action\Controller {
 			));
 		}
 
-		$post = Post::first($_id);
+		$post = Posts::first($_id);
 		if (empty($post)) {
 			return $this->redirect(array('controller' => 'posts', 'action' => 'index'));
 		}
@@ -86,7 +85,7 @@ class PostsController extends \lithium\action\Controller {
 	}
 
 	public function edit($_id = null) {
-		$post = Post::find($_id);
+		$post = Posts::find($_id);
 		if (empty($post)) {
 			return $this->redirect(array('controller' => 'posts', 'action' => 'index'));
 		}

--- a/controllers/SearchController.php
+++ b/controllers/SearchController.php
@@ -2,7 +2,7 @@
 
 namespace app\controllers;
 
-use app\models\Post;
+use app\models\Posts;
 
 class SearchController extends \lithium\action\Controller {
 
@@ -28,8 +28,8 @@ class SearchController extends \lithium\action\Controller {
 		$limit = $this->_limit;
 		$offset = ($page - 1) * $limit;
 
-		$count = Post::find('count', compact('conditions'));
-		$results = Post::find('all', compact('conditions','limit','offset'));
+		$count = Posts::find('count', compact('conditions'));
+		$results = Posts::find('all', compact('conditions','limit','offset'));
 		$url = $this->request->params + $data;
 
 		return compact('q','results','count','url','page','limit');
@@ -88,8 +88,8 @@ class SearchController extends \lithium\action\Controller {
 		$limit = $this->_limit;
 		$offset = ($page - 1) * $limit;
 
-		$count = Post::find('count', compact('conditions'));
-		$results = Post::find('all', compact('conditions','order','offset','limit'));
+		$count = Posts::find('count', compact('conditions'));
+		$results = Posts::find('all', compact('conditions','order','offset','limit'));
 
 		$url = $this->request->params;
 
@@ -117,8 +117,8 @@ class SearchController extends \lithium\action\Controller {
 		$limit = $this->_limit;
 		$offset = ($page - 1) * $limit;
 
-		$count = Post::find('count', compact('conditions'));
-		$results = Post::find('all', compact('conditions', 'order','offset','limit'));
+		$count = Posts::find('count', compact('conditions'));
+		$results = Posts::find('all', compact('conditions', 'order','offset','limit'));
 
 		return compact('results','count','url','page','limit');
 	}

--- a/extensions/helper/Post.php
+++ b/extensions/helper/Post.php
@@ -42,7 +42,7 @@ class Post extends \lithium\template\Helper {
 		$category = null;
 		if (!empty($post->tags)) {
 			foreach ($post->tags as $tag) {
-				if (!in_array($tag, \app\models\Post::$tags)) {
+				if (!in_array($tag, \app\models\Posts::$tags)) {
 					continue;
 				}
 				$category = $tag;
@@ -118,7 +118,7 @@ class Post extends \lithium\template\Helper {
 
 		$title = String::insert($title, compact('tag'));
 		$url = array('controller' => 'search', 'action' => 'filter') + compact('tag');
-		if (in_array($tag, \app\models\Post::$tags)) {
+		if (in_array($tag, \app\models\Posts::$tags)) {
 			$url = $tag;
 		}
 		$html = $this->_context->helper('html');

--- a/libraries/li3_users/config/bootstrap/session.php
+++ b/libraries/li3_users/config/bootstrap/session.php
@@ -19,7 +19,7 @@ Auth::config(array(
 			)
 		),
 		'adapter' => 'Form',
-		'model' => '\li3_users\models\User',
+		'model' => '\li3_users\models\Users',
 		'fields' => array('_id', 'password'),
 		'validators' => array(
 			'password' => function($submitted, $actual) {

--- a/libraries/li3_users/controllers/UsersController.php
+++ b/libraries/li3_users/controllers/UsersController.php
@@ -8,7 +8,7 @@
 
 namespace li3_users\controllers;
 
-use li3_users\models\User;
+use li3_users\models\Users;
 use lithium\security\Auth;
 use lithium\storage\Session;
 use li3_swiftmailer\mailer\Transports;
@@ -22,7 +22,7 @@ class UsersController extends \lithium\action\Controller {
 	protected $_cooldown = 6;
 
 	public function index() {
-		$users = User::all();
+		$users = Users::all();
 		return compact('users');
 	}
 
@@ -70,14 +70,14 @@ class UsersController extends \lithium\action\Controller {
 	}
 
 	public function view($_id = null) {
-		$user = User::find($_id);
+		$user = Users::find($_id);
 		return compact('user');
 	}
 
 	public function register() {
 		$errors = false;
 		if (!empty($this->request->data)) {
-			$user = User::create($this->request->data);
+			$user = Users::create($this->request->data);
 			if ($user->save()) {
 				Session::write('attempts', 0, array('name' => 'cooldown'));
 				return $this->redirect(array(
@@ -87,13 +87,13 @@ class UsersController extends \lithium\action\Controller {
 			$errors = $user->errors();
 		}
 		if (empty($user)) {
-			$user = User::create();
+			$user = Users::create();
 		}
 		return compact('user', 'errors');
 	}
 
 	public function edit($_id = null) {
-		$user = User::find($_id);
+		$user = Users::find($_id);
 		if (empty($user)) {
 			$this->redirect(array('controller' => 'users', 'action' => 'index'));
 		}
@@ -127,8 +127,8 @@ class UsersController extends \lithium\action\Controller {
 			$title = "update your password";
 			if (!empty($this->request->data['_id']) && !empty($this->request->data['password'])) {
 				$_id = $this->request->data['_id'];
-				if (User::reset(compact('token','_id'))) {
-					$user = User::first($this->request->data['_id']);
+				if (Users::reset(compact('token','_id'))) {
+					$user = Users::first($this->request->data['_id']);
 					$user->set(array('password' => $this->request->data['password']));
 					$success = $user->save();
 					$title = 'password updated!';
@@ -149,7 +149,7 @@ class UsersController extends \lithium\action\Controller {
 		}
 
 		if (empty($token) && !empty($this->request->data['_id'])) {
-			if ($user = User::first($this->request->data['_id'])) {
+			if ($user = Users::first($this->request->data['_id'])) {
 				$user->token();
 				if ($this->_emailToken($user->data())) {
 					$emailed = true;

--- a/libraries/li3_users/models/Users.php
+++ b/libraries/li3_users/models/Users.php
@@ -21,12 +21,12 @@ Validator::add('uniqueUserValue', function ($value, $format, $options) {
 			}
 			$conditions['_id'] = array('$ne' => $options['values']['_id']);
 		}
-		return !(boolean) User::find('count', compact('conditions'));
+		return !(boolean) Users::find('count', compact('conditions'));
 	}
 	return false;
 });
 
-class User extends \lithium\data\Model {
+class Users extends \lithium\data\Model {
 
 	protected $_meta = array(
 		'key' => '_id',

--- a/libraries/li3_users/tests/cases/models/UsersTest.php
+++ b/libraries/li3_users/tests/cases/models/UsersTest.php
@@ -11,7 +11,7 @@ namespace li3_users\tests\cases\models;
 use lithium\data\Connections;
 use lithium\data\model\Query;
 
-class User extends \li3_users\models\User {
+class Users extends \li3_users\models\Users {
 
 	protected $_meta = array(
 		'key' => '_id',
@@ -26,12 +26,12 @@ class User extends \li3_users\models\User {
 
 }
 
-class UserTest extends \lithium\test\Unit {
+class UsersTest extends \lithium\test\Unit {
 
 	public function setUp() {}
 
 	public function tearDown() {
-		User::find('all')->each(function($i) {
+		Users::find('all')->each(function($i) {
 			$i->delete();
 		});
 	}
@@ -42,7 +42,7 @@ class UserTest extends \lithium\test\Unit {
 			'email' => 'user@example.com',
 			'password' => 'my_password'
 		);
-		$user = User::create();
+		$user = Users::create();
 		$user->save($data);
 
 		$this->assertTrue(empty($user->token));
@@ -74,28 +74,28 @@ class UserTest extends \lithium\test\Unit {
 			'password' => 'my_password'
 		);
 
-		$result = User::reset();
+		$result = Users::reset();
 		$expected = false;
 		$this->assertEqual($expected, $result);
 
-		$user = User::create();
+		$user = Users::create();
 		$user->save($data);
 
 		$token = $user->token();
 
-		$result = User::reset(compact('token'));
+		$result = Users::reset(compact('token'));
 		$this->assertFalse($result);
 
 		$_id = $data['_id'];
 
-		$result = User::reset(compact('_id'));
+		$result = Users::reset(compact('_id'));
 		$this->assertFalse($result);
 
-		$result = User::reset(compact('token','_id'));
+		$result = Users::reset(compact('token','_id'));
 		$this->assertTrue($result);
 
 		$token = $user->token(strtotime('-15 minutes'));
-		$result = User::reset(compact('token','_id'));
+		$result = Users::reset(compact('token','_id'));
 		$this->assertFalse($result);
 
 	}

--- a/models/Comments.php
+++ b/models/Comments.php
@@ -2,7 +2,7 @@
 
 namespace app\models;
 
-class Comment extends \lithium\data\Model {
+class Comments extends \lithium\data\Model {
 
 	public $validates = array(
 		'content' => array('notEmpty', 'message' => 'Please supply some content.'),

--- a/models/Posts.php
+++ b/models/Posts.php
@@ -2,7 +2,7 @@
 
 namespace app\models;
 
-class Post extends \lithium\data\Model {
+class Posts extends \lithium\data\Model {
 
 	public $validates = array(
 		'title' => array('notEmpty', 'message' => 'Please supply a title.'),
@@ -54,8 +54,8 @@ class Post extends \lithium\data\Model {
 		'inflector'   => 'lithium\util\Inflector',
 		'set'         => 'lithium\data\collection\DocumentSet',
 		'session'     => 'lithium\storage\Session',
-		'user'        => 'li3_users\models\User',
-		'comment'     => 'app\models\Comment',
+		'users'        => 'li3_users\models\Users',
+		'comments'     => 'app\models\Comments',
 	);
 
 	public static function __init(array $options = array()) {
@@ -115,7 +115,7 @@ class Post extends \lithium\data\Model {
 			if (!empty($result->comments)) {
 				$comments = new $classes['set'](array(
 					'data' => $result->comments->data(),
-					'model' => $classes['comment']
+					'model' => $classes['comments']
 				));
 				$result->set(compact('comments'));
 			}
@@ -127,7 +127,7 @@ class Post extends \lithium\data\Model {
 		if (!empty($record->_user)) {
 			return $record->_user;
 		}
-		$user = static::$_classes['user'];
+		$user = static::$_classes['users'];
 		return $record->_user = $user::find($record->user_id);
 	}
 
@@ -136,7 +136,7 @@ class Post extends \lithium\data\Model {
 		$params += $default;
 		extract($params);
 
-		$comment = static::$_classes['comment'];
+		$comment = static::$_classes['comments'];
 		$comment = $comment::create($data);
 
 		if (empty($record->_id) || !$comment->save()) {
@@ -231,7 +231,7 @@ class Post extends \lithium\data\Model {
 		if (!empty($record->comments)) {
 			$comments = new $set(array(
 				'data' => $record->comments->data(),
-				'model' => 'app\models\Comment',
+				'model' => 'app\models\Comments',
 			));
 		}
 		return $comments;

--- a/tests/cases/extensions/helper/ThreadTest.php
+++ b/tests/cases/extensions/helper/ThreadTest.php
@@ -3,7 +3,7 @@
 namespace app\tests\cases\extensions\helper;
 
 use \app\extensions\helper\Thread;
-use \lithium\data\collection\Document;
+use \lithium\data\collection\DocumentSet as Document;
 use \lithium\net\http\Router;
 
 class ThreadTest extends \lithium\test\Unit {
@@ -38,7 +38,7 @@ class ThreadTest extends \lithium\test\Unit {
 			)
 		);
 
-		$document = new Document(array('items' => $data, 'model' => '\app\models\Post'));
+		$document = new Document(array('items' => $data, 'model' => '\app\models\Posts'));
 		$result = $thread->comments($document);
 		$this->assertNull($result);
 
@@ -59,7 +59,7 @@ class ThreadTest extends \lithium\test\Unit {
 			)
 		);
 
-		$document = new Document(array('items' => $data, 'model' => '\app\models\Post'));
+		$document = new Document(array('items' => $data, 'model' => '\app\models\Posts'));
 		$result = $thread->comments($document);
 		$this->assertTrue(!empty($result));
 	}

--- a/tests/cases/models/PostsTest.php
+++ b/tests/cases/models/PostsTest.php
@@ -2,21 +2,21 @@
 
 namespace app\tests\cases\models;
 
-use app\tests\mocks\models\MockPost as Post;
+use app\tests\mocks\models\MockPosts as Posts;
 use lithium\data\Connections;
 use lithium\data\model\Query;
 use lithium\util\Inflector;
 
-class PostTest extends \lithium\test\Unit {
+class PostsTest extends \lithium\test\Unit {
 
 	public function setUp() {}
 
 	public function tearDown() {
-		Post::all()->delete();
+		Posts::all()->delete();
 	}
 
 	public function testSave() {
-		$post = Post::create(array('title' => 'the title', 'content' => 'the content'));
+		$post = Posts::create(array('title' => 'the title', 'content' => 'the content'));
 		$expected = Inflector::slug($post->title);
 		$save = $post->save();
 		$result = strstr($post->_id, $expected);
@@ -25,21 +25,21 @@ class PostTest extends \lithium\test\Unit {
 		$data = $post->data();
 		unset($data['_id']);
 
-		$new = Post::create($data);
+		$new = Posts::create($data);
 		$new->save($data);
 		$this->assertNotEqual($post->_id, $new->_id);
 
 		$expected = $content = 'updated content';
 		$post->save(compact('content'));
-		$post = Post::first($post->_id);
+		$post = Posts::first($post->_id);
 		$this->assertEqual($expected, $post->content);
 
-		$post = Post::create(array('title' => 'sm', 'content' => 'title too short'));
+		$post = Posts::create(array('title' => 'sm', 'content' => 'title too short'));
 		$title = $post->title;
 		$post->save();
 		$this->assertNotEqual($title, $post->_id);
 
-		$post = Post::create(array(
+		$post = Posts::create(array(
 			'title' => 'test',
 			'content' => 'testing tags',
 			'tags' => 'one,Tag Two, ∆three, '
@@ -54,7 +54,7 @@ class PostTest extends \lithium\test\Unit {
 		$result = $post->user_id;
 		$this->assertEqual($expected, $result);
 
-		$post = Post::create(array(
+		$post = Posts::create(array(
 			'title' => 'forcing user id',
 			'content' => 'shtuff',
 			'user_id' => 'lithosphere'
@@ -67,7 +67,7 @@ class PostTest extends \lithium\test\Unit {
 	}
 
 	public function testPostUser() {
-		$post = Post::create(array(
+		$post = Posts::create(array(
 			'title' => 'my title',
 			'content' => 'jurassic park 3 sucked'
 		));
@@ -85,7 +85,7 @@ class PostTest extends \lithium\test\Unit {
 		$result = $user->_id;
 		$this->assertEqual($expected, $result);
 
-		$post = Post::create(array(
+		$post = Posts::create(array(
 			'title' => 'new title',
 			'content' => 'titanic 2 was ok',
 			'user_id' => 'gwoo'
@@ -97,7 +97,7 @@ class PostTest extends \lithium\test\Unit {
 		$result = $user->_id;
 		$this->assertEqual($expected, $result);
 
-		$post = Post::create(array(
+		$post = Posts::create(array(
 			'title' => 'how i do this?',
 			'content' => 'LOL',
 			'user_id' => 'mork'
@@ -115,7 +115,7 @@ class PostTest extends \lithium\test\Unit {
 			'_id' => 'gwoo',
 			'email' => 'gwoo@example.com'
 		);
-		$post = Post::create(array('title' => 'another title', 'content' => 'the content'));
+		$post = Posts::create(array('title' => 'another title', 'content' => 'the content'));
 		$post->save();
 
 		$data = array('content' => 'cool') + compact('user');
@@ -211,7 +211,7 @@ class PostTest extends \lithium\test\Unit {
 
 	public function testEndorsePost() {
 
-		$post = Post::create(array(
+		$post = Posts::create(array(
 			'title' => 'another title',
 			'content' => 'the content',
 			'user_id' => 'albert'
@@ -274,7 +274,7 @@ class PostTest extends \lithium\test\Unit {
 	}
 
 	public function testEndorseComment() {
-		$post = Post::create(array(
+		$post = Posts::create(array(
 			'title' => 'another title',
 			'content' => 'the content',
 			'user_id' => 'albert'
@@ -416,7 +416,7 @@ class PostTest extends \lithium\test\Unit {
 	}
 
 	public function testRating() {
-		$post = Post::create(array('title' => 'unrated', 'content' => '[REDACTED]'));
+		$post = Posts::create(array('title' => 'unrated', 'content' => '[REDACTED]'));
 	}
 }
 

--- a/tests/mocks/models/MockComments.php
+++ b/tests/mocks/models/MockComments.php
@@ -2,7 +2,7 @@
 
 namespace app\tests\mocks\models;
 
-class MockComment extends \app\models\Comment {
+class MockComments extends \app\models\Comments {
 
 	protected static $_classes = array(
 		'session' => 'app\tests\mocks\extensions\storage\MockSession'

--- a/tests/mocks/models/MockPosts.php
+++ b/tests/mocks/models/MockPosts.php
@@ -2,7 +2,7 @@
 
 namespace app\tests\mocks\models;
 
-class MockPost extends \app\models\Post {
+class MockPosts extends \app\models\Posts {
 
 	protected $_meta = array(
 		'connection' => 'test',
@@ -10,9 +10,9 @@ class MockPost extends \app\models\Post {
 	);
 
 	protected static $_classes = array(
-		'user'    => 'app\tests\mocks\models\MockUser',
+		'users'    => 'app\tests\mocks\models\MockUsers',
 		'session' => 'app\tests\mocks\extensions\storage\MockSession',
-		'comment' => 'app\tests\mocks\models\MockComment'
+		'comments' => 'app\tests\mocks\models\MockComments'
 	);
 }
 

--- a/tests/mocks/models/MockUsers.php
+++ b/tests/mocks/models/MockUsers.php
@@ -5,7 +5,7 @@ namespace app\tests\mocks\models;
 use lithium\data\collection\DocumentSet;
 use lithium\data\entity\Document;
 
-class MockUser extends \lithium\data\Model {
+class MockUsers extends \lithium\data\Model {
 
 	protected $_meta = array(
 		'connection' => false,


### PR DESCRIPTION
I recently saw some folks on IRC being confused about Lithium's convention for naming models.
Sphere models was singular. This pluralize them all.

Changed as well a call to `\lithium\data\collection\Document` to `DocumentSet` since `Document` class was splited 2 years ago ;)
